### PR TITLE
fix(gwf-parser): add opportunity to parse russian identifiers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix gwf-parser. Add opportunity to parse russian identifiers.
 
 ## [0.6.1] - 28.04.2022
 ### Added

--- a/scripts/kb_scripts/support_scripts/scs_writer.py
+++ b/scripts/kb_scripts/support_scripts/scs_writer.py
@@ -270,7 +270,10 @@ class SCsWriter:
                 el["idtf"] = "{}".format(idtf[1:].replace("-", "_"))
 
         if main_idtf is not None:
-            buffer.write("\n{}\n => {}: {};;\n".format(el["idtf"], self.kNrelMainIdtf, main_idtf))
+            if main_idtf.startswith("["):
+                buffer.write("\n{}\n => {}: {};;\n".format(el["idtf"], self.kNrelMainIdtf, main_idtf))
+            else:
+                buffer.write("\n{}\n => {}: [{}];;\n".format(el["idtf"], self.kNrelMainIdtf, main_idtf))
 
     @staticmethod
     def make_alias(prefix, element_id):


### PR DESCRIPTION
PR solve problem with parse russian identifiers like as:

![image](https://user-images.githubusercontent.com/56268020/170090119-e8914ecd-88c4-4695-be35-9e288a750512.png)
