### PR TITLE
Dockerized platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,37 @@ processing with tools to interact with it;
 # Installation
 ## Using Docker
 You will need [Docker](https://docs.docker.com/get-docker/) installed and running on your machine.
+
 ```sh
+git clone https://github.com/ostis-ai/ostis-web-platform
 cd ostis-web-platform
 docker compose pull
 ```
+
+<details> 
+<summary> Building images locally </summary>
+
+e.g. when you want to launch a custom branch of sc-machine/sc-web
+#### Requirements
+1. **If you're using Windows**, please make sure you are using UNIX line endings inside the repository and `longpaths` are enabled:
+   ```
+   git config --local core.autocrlf true
+   git config --local core.longpaths true
+   git add --normalize .
+   ```
+2. Enable Docker BuildKit. You can use `DOCKER_BUILDKIT=1` shell variable for this.
+
+```sh
+git clone https://github.com/ostis-ai/ostis-web-platform
+git submodule update --init --recursive
+cd scripts
+./prepare.sh no_build_sc_web no_build_sc_web no_build_kb # download all submodules (without compilation)
+cd ..
+docker compose build
+```
+</details>
+
+
 
 
 ## Natively

--- a/README.md
+++ b/README.md
@@ -16,15 +16,32 @@ processing with tools to interact with it;
 3) [Web-oriented semantic interface](https://github.com/ostis-ai/sc-web) to users interact with the IMS system.
 
 # Installation
-To run OSTIS Technology platform execute the following scripts to install and build all their submodules:
+## Using Docker
+You will need [Docker](https://docs.docker.com/get-docker/) installed and running on your machine.
+```sh
+cd ostis-web-platform
+docker compose pull
+```
 
-## Initiate and update submodules
+
+## Natively
+Note: Currently only Ubuntu is supported by this installation method. If you're going to use it, all build-time dependencies will be downloaded to your computer, and it might take a while to compile the `sc-machine`. Use it only if you know what you're doing!
 ```sh
 cd ostis-web-platform/scripts/
 ./prepare.sh
 ```
 
 # Usage
+## Docker
+```sh
+# This command will build the Knowledge Base.
+# You need to launch it only before the first launch (or if you've made updates to KB sources)
+docker compose run machine build
+# This will start platform services and run web interface at localhost:8000
+docker compose up
+```
+
+## Native installation
 After run the following script for sc-server to interact with knowledge processing machine:
 ```sh
 cd ostis-web-platform/scripts/
@@ -43,15 +60,13 @@ base to provide opportunity to use it in information processing and knowledge cr
 the help of LaTex tools in SCn-code representation. To see more information about [the OSTIS Technology](https://github.com/ostis-ai/ostis-standard) 
 web-oriented platform implementation:
 
-## Docker
-We're providing a Docker image to build the documentation. Head to [Installing with Docker](https://docs.docker.com/get-started/) 
-section of our docs to try it out!
+We're providing a Docker image to build the documentation.
 
 To do that, run docker image:
 ```sh
-cd ostis-web-platform/docs/scn/
-docker run -v </full/path/to/ostis-web-platform>:/workdir ostis/scntex-builder 'cd docs && pdflatex -interaction=nonstopmode main.tex'
+docker run -v <path/to/ostis-web-platform/>:/workdir ostis/scntex-builder 'cd docs && pdflatex -interaction=nonstopmode main.tex'
 ```
+
 After the compilation, the `main.pdf` file should appear at `ostis-web-platform/docs/`.
 
 Alternatively, you can use any LaTeX distribution to build and view the documentation, but you will have to install all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  web:
+    image: ostis/sc-web
+    build:
+      context: ./sc-web
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    networks:
+      - sc-machine
+    command:
+      - "--server-host=machine"
+    depends_on:
+      machine:
+        condition: service_healthy
+
+  machine:
+    image: ostis/sc-machine
+    build:
+      context: ./sc-machine
+    restart: unless-stopped
+    volumes:
+      - ./:/kb
+      - kb-binary:/kb.bin
+    networks:
+      - sc-machine
+    ports:
+      - "8090:8090"
+    healthcheck:
+      test: "python3 /sc-machine/scripts/healthcheck.py"
+      interval: 5s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+    environment:
+      # Use the commented env variable if you need to rebuild KB every startup.
+      #- "REBUILD_KB=1"
+      - "KB_PATH=/kb/repo.path"
+    command:
+      - "serve"
+
+volumes:
+  kb-binary: {}
+
+networks:
+  sc-machine: {}

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -12,6 +12,7 @@ st=1
 
 build_kb=1
 build_sc_machine=1
+build_sc_web=1
 
 set -eo pipefail
 
@@ -24,6 +25,8 @@ while [ "$1" != "" ]; do
 			build_sc_machine=0
 			build_kb=0
 			;;
+		"no_build_sc_web" )
+			build_sc_web=0
 	esac
 	shift
 done
@@ -66,7 +69,7 @@ prepare "sc-machine"
 cd ../sc-machine
 git submodule update --init --recursive
 
-
+if (( $build_sc_machine == 1 )); then
 cd scripts
 ./install_deps_ubuntu.sh --dev
 
@@ -77,13 +80,13 @@ pip3 install -r requirements.txt
 
 
 cd scripts
-if (( $build_sc_machine == 1 )); then
 	./make_all.sh
 fi
 cd ..
 
 
 prepare "sc-web"
+if (( $build_sc_web == 1 )); then
 pip3 install --default-timeout=100 future
 
 
@@ -97,6 +100,7 @@ pip3 install -r requirements.txt
 
 npm install
 npm run build
+fi
 
 if (( $build_kb == 1 )); then
 	stage "Build knowledge base"

--- a/scripts/run_sc_server.sh
+++ b/scripts/run_sc_server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export LD_LIBRARY_PATH=../sc-machine/bin
-python3 ../sc-machine/scripts/run_sc_server.py -c ../ostis-web-platform.ini
+../sc-machine/bin/sc-server -c ../ostis-web-platform.ini

--- a/scripts/run_scweb.sh
+++ b/scripts/run_scweb.sh
@@ -1,5 +1,2 @@
 #!/bin/bash
-
-cd ../sc-web/scripts
-./run_scweb.sh
-cd -
+../sc-web/scripts/run_scweb.sh


### PR DESCRIPTION
This PR depends on https://github.com/ostis-ai/sc-web/pull/10, https://github.com/ostis-ai/sc-machine/pull/140 and https://github.com/ostis-ai/sc-machine/pull/142
Changes:
- The whole Platform can be installed using Docker Compose, which is a big deal for users with unsupported OSes or hardware for native compilation.
- Launch scripts for native installation are updated to be in sync with latest changes in `sc-machine` and `sc-web`